### PR TITLE
PLACEHOLDER: Allow environment to set API key

### DIFF
--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -5,7 +5,7 @@ import boto3
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
-from api.setting import DEFAULT_API_KEYS
+from api.setting import DEFAULT_API_KEY
 
 api_key_param = os.environ.get("API_KEY_PARAM_NAME")
 if api_key_param:
@@ -14,7 +14,7 @@ if api_key_param:
         "Value"
     ]
 else:
-    api_key = DEFAULT_API_KEYS
+    api_key = DEFAULT_API_KEY
 
 security = HTTPBearer()
 

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -1,6 +1,6 @@
 import os
 
-DEFAULT_API_KEYS = "bedrock"
+DEFAULT_API_KEY = os.environ.get("BEDROCK_PROXY_API_KEY", "bedrock")
 
 API_ROUTE_PREFIX = "/api/v1"
 


### PR DESCRIPTION
I threw this together before I realised there's an almost-identical PR here: https://github.com/aws-samples/bedrock-access-gateway/pull/40

Once that's merged we can ditch this entire fork, but it's had no movement on it for months so who knows if it'll ever get merged 🤷. Maintaining our own fork for now so we can pick up changes on `main` as and when we need to.

Not intending to merge this so leaving as draft